### PR TITLE
Add MessageId to clustering key

### DIFF
--- a/src/Abc.Zebus.Persistence.CQL/Data/PersistentMessage.cs
+++ b/src/Abc.Zebus.Persistence.CQL/Data/PersistentMessage.cs
@@ -1,4 +1,5 @@
-﻿using Cassandra.Mapping.Attributes;
+﻿using System;
+using Cassandra.Mapping.Attributes;
 
 namespace Abc.Zebus.Persistence.CQL.Data
 {
@@ -13,9 +14,13 @@ namespace Abc.Zebus.Persistence.CQL.Data
         [Column("BucketId")]
         public long BucketId { get; set; }
 
-        [ClusteringKey]
+        [ClusteringKey(0)]
         [Column("UniqueTimestampInTicks")]
         public long UniqueTimestampInTicks { get; set; }
+
+        [ClusteringKey(1)]
+        [Column("MessageId")]
+        public Guid MessageId { get; set; }
 
         [Column("IsAcked")]
         public bool IsAcked { get; set; }

--- a/src/Abc.Zebus.Persistence.CQL/Storage/CqlStorage.cs
+++ b/src/Abc.Zebus.Persistence.CQL/Storage/CqlStorage.cs
@@ -72,6 +72,7 @@ namespace Abc.Zebus.Persistence.CQL.Storage
                 var insertTask = _parallelPersistor.Insert(_preparedStatement.Bind(matcherEntry.PeerId.ToString(),
                                                                                BucketIdHelper.GetBucketId(messageDateTime),
                                                                                messageDateTime.Ticks,
+                                                                               matcherEntry.MessageId.Value,
                                                                                matcherEntry.IsAck,
                                                                                matcherEntry.MessageBytes,
                                                                                (int)PersistentMessagesTimeToLive.TotalSeconds,

--- a/src/Abc.Zebus.Persistence.CQL/Util/ParallelPersistor.cs
+++ b/src/Abc.Zebus.Persistence.CQL/Util/ParallelPersistor.cs
@@ -58,7 +58,6 @@ namespace Abc.Zebus.Persistence.CQL.Util
                         }
                         catch (InvalidOperationException) // thrown by BufferBlock when stopping
                         {
-                            _log.Info("Received stop signal");
                             break;
                         }
                         catch (Exception ex)

--- a/src/Abc.Zebus.Persistence.CQL/schema/1.1/01_Create_PersistentMessage.cql
+++ b/src/Abc.Zebus.Persistence.CQL/schema/1.1/01_Create_PersistentMessage.cql
@@ -1,0 +1,9 @@
+CREATE TABLE "PersistentMessage" (
+	"PeerId" ascii,
+	"BucketId" bigint,
+	"UniqueTimestampInTicks" bigint,
+	"MessageId" uuid,
+	"IsAcked" boolean,
+	"TransportMessage" blob,
+	PRIMARY KEY (( "PeerId", "BucketId" ), "UniqueTimestampInTicks", "MessageId")
+);

--- a/src/SharedVersionInfo.cs
+++ b/src/SharedVersionInfo.cs
@@ -1,5 +1,5 @@
 ﻿using System.Reflection;
 
-[assembly: AssemblyVersion("1.0.3")]
-[assembly: AssemblyFileVersion("1.0.3")]
-[assembly: AssemblyInformationalVersion("1.0.3")]
+[assembly: AssemblyVersion("1.1.0")]
+[assembly: AssemblyFileVersion("1.1.0")]
+[assembly: AssemblyInformationalVersion("1.1.0")]


### PR DESCRIPTION
The previous clustering key only included the time component of the MessageId, supposing that timestamps were unique. 
This was safe to assume for a single Peer, since timestamps are guarantied to be unique for a given Peer by Zebus, but it presented a risk of message overwrite if two Peers sent a message to the same destination at the exact same time.

Performance tests show a 10% drop in both read and write, most likely due to the extra data (MessageId) transferred.